### PR TITLE
Num and sqrt variables seem to have been swapped.

### DIFF
--- a/docs/articles/nunit/writing-tests/attributes/theory.md
+++ b/docs/articles/nunit/writing-tests/attributes/theory.md
@@ -90,7 +90,7 @@ public class SqrtTests
         double sqrt = Math.Sqrt(num);
 
         Assert.That(sqrt >= 0.0);
-        Assert.That(sqrt * sqrt, Is.EqualTo(num).Within(0.000001));
+        Assert.That(num * num, Is.EqualTo(sqrt).Within(0.000001));
     }
 }
 ```


### PR DESCRIPTION
Just a little nitpick in the example provided. The num and sqrt values seem to have been swapped.

`num * num` should equal `Sqrt(num)`, not the other way around.